### PR TITLE
Use Select-Object instead of Select

### DIFF
--- a/UpdateOS/UpdateOS.ps1
+++ b/UpdateOS/UpdateOS.ps1
@@ -80,7 +80,7 @@ $null = Install-Module PSWindowsUpdate -Force
 Import-Module PSWindowsUpdate
 
 # Install all available updates
-Get-WindowsUpdate -Install -IgnoreUserInput -AcceptAll -WindowsUpdate -IgnoreReboot | Select Title, KB, Result | Format-Table
+Get-WindowsUpdate -Install -IgnoreUserInput -AcceptAll -WindowsUpdate -IgnoreReboot | Select-Object Title, KB, Result | Format-Table
 $needReboot = (Get-WURebootStatus -Silent).RebootRequired
 
 # Specify return code


### PR DESCRIPTION
Ref: https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/AvoidUsingCmdletAliases.md
> 'Select' is an alias of 'Select-Object'. Alias can introduce possible problems and make scripts hard to maintain. Please consider changing alias to its full content.